### PR TITLE
Update package.json to maintain current dependency version for eleven…

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "maintained node versions"
   ],
   "dependencies": {
-    "@11ty/eleventy-fetch": "^4.0.1",
+    "@11ty/eleventy-fetch": "^4.0.1"
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the version of the `@11ty/eleventy-fetch` dependency without altering its version number.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42-R42): Updated the `@11ty/eleventy-fetch` dependency version to ensure it remains at `^4.0.1`.