### PR TITLE
Remove UpgradeHelper plugin from Eleventy configuration

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,7 +8,6 @@ import markdownItAnchor from 'markdown-it-anchor';
 import syntaxHighlight from '@11ty/eleventy-plugin-syntaxhighlight';
 import pluginWebc from '@11ty/eleventy-plugin-webc';
 import { EleventyRenderPlugin } from '@11ty/eleventy';
-import UpgradeHelper from '@11ty/eleventy-upgrade-help';
 import Image from '@11ty/eleventy-img';
 import getTagList from './_11ty/getTagList.js';
 


### PR DESCRIPTION
This pull request involves a minor change to the `.eleventy.js` configuration file, specifically the removal of an unused import statement.

Codebase cleanup:

* [`.eleventy.js`](diffhunk://#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0L11): Removed the import statement for `UpgradeHelper` to clean up the codebase.